### PR TITLE
feat: 에러 핸들링 추가

### DIFF
--- a/src/main/java/com/efub/lakkulakku/global/exception/ErrorCode.java
+++ b/src/main/java/com/efub/lakkulakku/global/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.efub.lakkulakku.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	// Common
+	DUPLICATE_DIARY_DATE(CONFLICT, "C0001", "DUPLICATE_DIARY_EXISTS");
+
+	// Standard
+
+	// Exception
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/efub/lakkulakku/global/exception/ErrorResponse.java
+++ b/src/main/java/com/efub/lakkulakku/global/exception/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.efub.lakkulakku.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class ErrorResponse {
+
+	private HttpStatus status;
+	private ErrorCode code;
+	private String message;
+	private LocalDateTime date = LocalDateTime.now();
+
+	@Builder
+	public ErrorResponse(HttpStatus status, ErrorCode code, String message){
+		this.status = status;
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/efub/lakkulakku/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/efub/lakkulakku/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.efub.lakkulakku.global.exception;
+
+import com.efub.lakkulakku.domain.diary.exception.DuplicateDiaryException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	// Diary 관련 error handler
+	@ExceptionHandler(DuplicateDiaryException.class)
+	protected final ResponseEntity<ErrorResponse> handleDuplicateDiaryException(DuplicateDiaryException e){
+		final ErrorResponse response = ErrorResponse.builder()
+			.status(HttpStatus.BAD_REQUEST)
+			.code(ErrorCode.DUPLICATE_DIARY_DATE)
+			.message(e.getMessage())
+			.build();
+		return ResponseEntity.status(response.getStatus()).body(response);
+	}
+
+	// 기본적인 RunTimeException handler
+	@ExceptionHandler(RuntimeException.class)
+	protected final ResponseEntity<ErrorResponse> handleRunTimeException(RuntimeException e){
+		final ErrorResponse response = ErrorResponse.builder()
+			.status(HttpStatus.BAD_REQUEST)
+			.code(ErrorCode.DUPLICATE_DIARY_DATE)
+			.message(e.getMessage())
+			.build();
+		return ResponseEntity.status(response.getStatus()).body(response);
+	}
+}


### PR DESCRIPTION
- globalExceptionHandler와 에러 코드, 에러Response 양식을 지정했습니다.
customException을 생성하고 에러 코드와 globalExceptionHandler에 해당 에러에 관한 정보를 추가하여 사용합니다.

사용 예시
<Controller>
```
	@PostMapping
	public ResponseEntity<Object> createDiary(@Valid @PathVariable String date) {
		if (diaryRepository.existsByDate(date))
			**throw new DuplicateDiaryException();**
		diaryService.createDiary(date);
		return ResponseEntity.ok().body("{date} 날짜의 다이어리가 생성되었습니다.");
	}
```

