### PR TITLE
fix : 친구 정보 불러오기 수정

### DIFF
--- a/src/main/java/com/efub/lakkulakku/domain/file/entity/File.java
+++ b/src/main/java/com/efub/lakkulakku/domain/file/entity/File.java
@@ -1,15 +1,13 @@
 package com.efub.lakkulakku.domain.file.entity;
 
+import com.efub.lakkulakku.domain.profile.entity.Profile;
 import com.efub.lakkulakku.global.entity.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
@@ -31,7 +29,7 @@ public class File extends BaseTimeEntity {
 	@NotNull
 	private String filetype;
 
-	@NotNull
+	@Column(nullable = true)
 	private String url;
 
 	@Builder

--- a/src/main/java/com/efub/lakkulakku/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/controller/FriendController.java
@@ -26,7 +26,6 @@ public class FriendController {
 	private final UsersRepository usersRepository;
 
 
-
 	@PostMapping("/search")
 	public ResponseEntity<?> searchFriend(@RequestBody FriendReqDto reqDto) {
 		Users user = usersRepository.findByUid(reqDto.getUid())
@@ -36,14 +35,13 @@ public class FriendController {
 	}
 
 	@PostMapping()
-	public ResponseEntity<?> addFriend(@AuthUsers Users user,  @RequestBody FriendReqDto reqDto) {
+	public ResponseEntity<?> addFriend(@AuthUsers Users user, @RequestBody FriendReqDto reqDto) {
 		friendService.addFriend(reqDto, user);
 		return ResponseEntity.ok(FRIEND_SUCCESS);
 	}
 
 	@GetMapping()
 	public List<FriendResDto> getFriends(@AuthUsers Users user) {
-
 		return friendService.getFriends(user);
 	}
 

--- a/src/main/java/com/efub/lakkulakku/domain/friend/dto/FriendResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/dto/FriendResDto.java
@@ -27,7 +27,11 @@ public class FriendResDto {
 	@Builder
 	public FriendResDto(Users user) {
 		this.uid = user.getUid();
-		this.profileImageUrl = user.getProfile().getFile().getUrl();
+		if (user.getProfile() == null || user.getProfile().getFile() == null) {
+			this.profileImageUrl = null;
+		} else {
+			this.profileImageUrl = user.getProfile().getFile().getUrl();
+		}
 		this.nickname = user.getNickname();
 	}
 

--- a/src/main/java/com/efub/lakkulakku/domain/profile/entity/Profile.java
+++ b/src/main/java/com/efub/lakkulakku/domain/profile/entity/Profile.java
@@ -27,12 +27,12 @@ public class Profile extends BaseTimeEntity {
 	private UUID id;
 
 
+	@OneToOne(mappedBy = "profile")
+	private Users users;
+
 	@OneToOne
 	@JoinColumn(name = "profile_image_id")
 	private File file;
-
-	@OneToOne(mappedBy = "profile")
-	private Users users;
 
 	private String bio;
 

--- a/src/main/java/com/efub/lakkulakku/domain/users/controller/HomeController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/controller/HomeController.java
@@ -4,6 +4,7 @@ import com.efub.lakkulakku.domain.diary.exception.BadDateRequestException;
 import com.efub.lakkulakku.domain.users.dto.HomeResDto;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import com.efub.lakkulakku.domain.users.repository.UsersRepository;
+import com.efub.lakkulakku.domain.users.service.AuthUsers;
 import com.efub.lakkulakku.domain.users.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,11 +22,10 @@ public class HomeController {
 	private final UsersService usersService;
 
 	@GetMapping
-	public ResponseEntity<HomeResDto> getHomeByDate(@PathVariable(value = "year", required = false) String year, @PathVariable(value = "month", required = false) String month) {
+	public ResponseEntity<HomeResDto> getHomeByDate(@AuthUsers Users user, @PathVariable(value = "year", required = false) String year, @PathVariable(value = "month", required = false) String month) {
 		//TODO : LocalDateTime의 범위를 넘어가는 경우 에러 발생
 		//TODO : 시큐리티 적용 후 유저 변경
-		Users user = usersRepository.findByNickname("ywyw").get(); // 테스트용 유저
-
+		//Users user = usersRepository.findByNickname("ywyw").get(); // 테스트용 유저
 		if (Integer.parseInt(year) <= 1969 || Integer.parseInt(year) >= 2100)
 			throw new BadDateRequestException();
 

--- a/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
+++ b/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
@@ -36,7 +36,7 @@ public class AppConfig {
 				.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 				.and()
 				.authorizeRequests()
-				.antMatchers("/api/v1/users/**").permitAll()
+				.antMatchers("/api/v1/users/**", "/api/v1/home/**").permitAll()
 				.anyRequest().authenticated()
 				.and()
 				.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
- 친구 프로필에서 사진이 null일 때 에러 응답
- 원인은 get을 통해 가져올 때 내부적으로  null 에러 발생시킴
- 조건을 추가하여 null 값도 가져올 수 있도록 함

resolves #21 