### PR TITLE
fix: 댓글 조회시 user id 수정

### DIFF
--- a/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentMapper.java
@@ -24,6 +24,7 @@ public class CommentMapper {
 
 		return CommentResDto.builder()
 				.id(entity.getId())
+				.userId(entity.getUsers().getId())
 				.nickname(entity.getUsers().getNickname())
 				.parentId(entity.getParentId())
 				.content(entity.getContent())


### PR DESCRIPTION
- 댓글 조회할 때 댓글의 user id 가 안보이는 문제 해결했습니다