### PR TITLE
feat: diaries Req, Res 필드 수정 및 /update 완성

### DIFF
--- a/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/dto/CommentMapper.java
@@ -58,9 +58,4 @@ public class CommentMapper {
 				.isSecret(dto.getIsSecret())
 				.build();
 	}
-
-	public Comment deleteAndCreateEntity(Diary diary, CommentResDto dto) {
-		commentRepository.deleteAllByDiaryId(diary.getId());
-		return toEntity(diary, dto);
-	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/comment/repository/CommentRepository.java
@@ -11,9 +11,12 @@ import java.util.UUID;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 	Optional<Comment> findById(UUID id);
+
 	Optional<Comment> findByUsers(Users users);
+
 	void deleteById(UUID id);
+
 	Optional<Comment> findByParentId(UUID parentId);
-	void deleteAllByDiaryId(UUID id);
+
 	int countByDiaryId(UUID id);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/controller/DiaryController.java
@@ -1,5 +1,6 @@
 package com.efub.lakkulakku.domain.diary.controller;
 
+import com.efub.lakkulakku.domain.diary.dto.DiaryLookupReqDto;
 import com.efub.lakkulakku.domain.diary.dto.DiaryLookupResDto;
 import com.efub.lakkulakku.domain.diary.dto.DiaryMessageResDto;
 import com.efub.lakkulakku.domain.diary.dto.DiarySaveReqDto;
@@ -63,26 +64,27 @@ public class DiaryController {
 	public ResponseEntity<DiaryMessageResDto> saveDiary(@AuthUsers Users user,
 														@PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
 														@RequestPart(value = "files", required = false) List<MultipartFile> files,
-														@RequestPart(value = "key") DiaryLookupResDto diaryLookupResDto) throws IOException {
+														@RequestPart(value = "key") DiaryLookupReqDto diaryLookupReqDto) throws IOException {
 
 		DiarySaveReqDto diarySaveReqDto = DiarySaveReqDto.builder()
 				.user(user)
 				.multipartFileList(files)
-				.diaryLookupResDto(diaryLookupResDto)
+				.diaryLookupReqDto(diaryLookupReqDto)
 				.build();
 		diaryService.saveDiary(date, diarySaveReqDto);
 		return ResponseEntity.ok().body(new DiaryMessageResDto(date + DIARY_UPDATE_SUCCESS));
 	}
 
-	@PatchMapping(value = "/update/{date}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+	@PostMapping(value = "/update/{date}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<DiaryMessageResDto> updateDiary(@AuthUsers Users user,
 														  @PathVariable("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
 														  @RequestPart(value = "files", required = false) List<MultipartFile> files,
-														  @RequestPart(value = "key") DiaryLookupResDto diaryLookupResDto) throws IOException {
+														  @RequestPart(value = "key") DiaryLookupReqDto diaryLookupReqDto) throws IOException {
+
 		DiarySaveReqDto diarySaveReqDto = DiarySaveReqDto.builder()
 				.user(user)
 				.multipartFileList(files)
-				.diaryLookupResDto(diaryLookupResDto)
+				.diaryLookupReqDto(diaryLookupReqDto)
 				.build();
 		diaryService.updateDiary(date, diarySaveReqDto);
 		return ResponseEntity.ok().body(new DiaryMessageResDto(date + DIARY_UPDATE_SUCCESS));

--- a/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryLookupReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryLookupReqDto.java
@@ -1,0 +1,40 @@
+package com.efub.lakkulakku.domain.diary.dto;
+
+import com.efub.lakkulakku.domain.comment.dto.CommentResDto;
+import com.efub.lakkulakku.domain.image.dto.ImageReqDto;
+import com.efub.lakkulakku.domain.likes.dto.LikeResDto;
+import com.efub.lakkulakku.domain.sticker.dto.StickerReqDto;
+import com.efub.lakkulakku.domain.template.dto.TemplateResDto;
+import com.efub.lakkulakku.domain.text.dto.TextReqDto;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiaryLookupReqDto {
+
+	private DiaryResDto diary;
+	private TemplateResDto template;
+	private List<TextReqDto> textList;
+	private List<ImageReqDto> imageList;
+	private List<StickerReqDto> stickerList;
+	private List<CommentResDto> commentList;
+	private List<LikeResDto> likeList;
+
+	@Builder
+	public DiaryLookupReqDto(DiaryResDto diary, TemplateResDto template,
+							 List<TextReqDto> textList, List<ImageReqDto> imageList, List<StickerReqDto> stickerList,
+							 List<CommentResDto> commentList, List<LikeResDto> likeList) {
+		this.diary = diary;
+		this.template = template;
+		this.textList = textList;
+		this.imageList = imageList;
+		this.stickerList = stickerList;
+		this.commentList = commentList;
+		this.likeList = likeList;
+	}
+}

--- a/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiaryMapper.java
@@ -58,12 +58,54 @@ public class DiaryMapper {
 	}
 
 	public Diary saveDiary(Diary entity, DiarySaveReqDto dto) throws IOException {
-		if (entity == null || dto == null)
+		if (dto == null)
 			return null;
 
-		DiaryLookupResDto diaryLookupResDto = dto.getDiaryLookupResDto();
+		DiaryLookupReqDto diaryLookupResDto = dto.getDiaryLookupReqDto();
 		DiaryResDto diaryResDto = diaryLookupResDto.getDiary();
 
+		DiaryEntityUpdateDto diaryEntityUpdateDto = DiaryEntityUpdateDto.builder()
+				.title(diaryResDto.getTitle())
+				.titleEmoji(diaryResDto.getTitleEmoji())
+				.template(templateMapper.toEntity(entity, diaryLookupResDto.getTemplate()))
+				.commentList(diaryLookupResDto.getCommentList().stream().filter(Objects::nonNull).map(commentResDto -> commentMapper.toEntity(entity, commentResDto)).collect(Collectors.toList()))
+				.imageList(imageToEntity(entity, dto))
+				.likesList(diaryLookupResDto.getLikeList().stream().filter(Objects::nonNull).map(likeResDto -> likeMapper.toEntity(entity, likeResDto)).collect(Collectors.toList()))
+				.textList(diaryLookupResDto.getTextList().stream().filter(Objects::nonNull).map(textReqDto -> textMapper.toEntity(entity, textReqDto)).collect(Collectors.toList()))
+				.stickerList(diaryLookupResDto.getStickerList().stream().filter(Objects::nonNull).map(stickerReqDto -> stickerMapper.toEntity(entity, stickerReqDto)).collect(Collectors.toList()))
+				.cntComment(diaryResDto.getCntComment())
+				.cntLike(diaryResDto.getCntLike())
+				.build();
+
+		entity.updateDiary(diaryEntityUpdateDto);
+		return entity;
+	}
+
+	public Diary updateDiary(Diary entity, DiarySaveReqDto dto) throws IOException {
+		if (dto == null)
+			return null;
+
+		DiaryLookupReqDto diaryLookupResDto = dto.getDiaryLookupReqDto();
+		DiaryResDto diaryResDto = diaryLookupResDto.getDiary();
+
+		DiaryEntityUpdateDto diaryEntityUpdateDto = DiaryEntityUpdateDto.builder()
+				.title(diaryResDto.getTitle())
+				.titleEmoji(diaryResDto.getTitleEmoji())
+				.template(templateMapper.toEntity(entity, diaryLookupResDto.getTemplate()))
+				.commentList(diaryLookupResDto.getCommentList().stream().filter(Objects::nonNull).map(commentResDto -> commentMapper.toEntity(entity, commentResDto)).collect(Collectors.toList()))
+				.imageList(imageToEntity(entity, dto))
+				.likesList(diaryLookupResDto.getLikeList().stream().filter(Objects::nonNull).map(likeResDto -> likeMapper.toEntity(entity, likeResDto)).collect(Collectors.toList()))
+				.textList(diaryLookupResDto.getTextList().stream().filter(Objects::nonNull).map(textReqDto -> textMapper.toEntity(entity, textReqDto)).collect(Collectors.toList()))
+				.stickerList(diaryLookupResDto.getStickerList().stream().filter(Objects::nonNull).map(stickerReqDto -> stickerMapper.toEntity(entity, stickerReqDto)).collect(Collectors.toList()))
+				.cntComment(diaryResDto.getCntComment())
+				.cntLike(diaryResDto.getCntLike())
+				.build();
+
+		entity.updateDiary(diaryEntityUpdateDto);
+		return entity;
+	}
+
+	public List<Image> imageToEntity(Diary entity, DiarySaveReqDto dto) throws IOException {
 		List<Image> imageList = new ArrayList<>();
 		if (dto.getMultipartFileList() != null) {
 			ImageToEntityDto imageToEntityDto = ImageToEntityDto.builder()
@@ -71,23 +113,8 @@ public class DiaryMapper {
 					.diary(entity)
 					.multipartFileList(dto.getMultipartFileList())
 					.build();
-			imageList = imageMapper.toEntityList(diaryLookupResDto.getImageList(), imageToEntityDto);
+			imageList = imageMapper.toEntityList(dto.getDiaryLookupReqDto().getImageList(), imageToEntityDto);
 		}
-
-		DiaryEntityUpdateDto diaryEntityUpdateDto = DiaryEntityUpdateDto.builder()
-				.title(diaryResDto.getTitle())
-				.titleEmoji(diaryResDto.getTitleEmoji())
-				.template(templateMapper.toEntity(entity, diaryLookupResDto.getTemplate()))
-				.commentList(diaryLookupResDto.getCommentList().stream().filter(Objects::nonNull).map(commentResDto -> commentMapper.toEntity(entity, commentResDto)).collect(Collectors.toList()))
-				.imageList(imageList)
-				.likesList(diaryLookupResDto.getLikeList().stream().filter(Objects::nonNull).map(likeResDto -> likeMapper.toEntity(entity, likeResDto)).collect(Collectors.toList()))
-				.textList(diaryLookupResDto.getTextList().stream().filter(Objects::nonNull).map(textResDto -> textMapper.toEntity(entity, textResDto)).collect(Collectors.toList()))
-				.stickerList(diaryLookupResDto.getStickerList().stream().filter(Objects::nonNull).map(stickerDiaryResDto -> stickerMapper.toEntity(entity, stickerDiaryResDto)).collect(Collectors.toList()))
-				.cntComment(diaryResDto.getCntComment())
-				.cntLike(diaryResDto.getCntLike())
-				.build();
-
-		entity.updateDiary(diaryEntityUpdateDto);
-		return entity;
+		return imageList;
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiarySaveReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/dto/DiarySaveReqDto.java
@@ -11,12 +11,12 @@ import java.util.List;
 public class DiarySaveReqDto {
 	Users user;
 	List<MultipartFile> multipartFileList;
-	DiaryLookupResDto diaryLookupResDto;
+	DiaryLookupReqDto diaryLookupReqDto;
 
 	@Builder
-	public DiarySaveReqDto(Users user, List<MultipartFile> multipartFileList, DiaryLookupResDto diaryLookupResDto){
+	public DiarySaveReqDto(Users user, List<MultipartFile> multipartFileList, DiaryLookupReqDto diaryLookupReqDto) {
 		this.user = user;
 		this.multipartFileList = multipartFileList;
-		this.diaryLookupResDto = diaryLookupResDto;
+		this.diaryLookupReqDto = diaryLookupReqDto;
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
@@ -50,23 +50,23 @@ public class Diary extends BaseTimeEntity {
 	@Column(length = 5)
 	private String titleEmoji;
 
-	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Comment> comments = new ArrayList<>();
 
-	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinColumn(name = "template_id")
 	private Template template;
 
-	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Image> images = new ArrayList<>();
 
-	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Likes> likes = new ArrayList<>();
 
-	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Text> texts = new ArrayList<>();
 
-	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Sticker> stickers = new ArrayList<>();
 
 	@Column(length = 10, columnDefinition = "bigint(10) default 0")//
@@ -110,12 +110,24 @@ public class Diary extends BaseTimeEntity {
 	public void updateDiary(DiaryEntityUpdateDto dto) {
 		this.title = dto.getTitle();
 		this.titleEmoji = dto.getTitleEmoji();
-		this.comments = dto.getCommentList();
+
+		this.comments.clear();
+		this.comments.addAll(dto.getCommentList());
+
 		this.template = dto.getTemplate();
-		this.images = dto.getImageList();
-		this.likes = dto.getLikesList();
-		this.texts = dto.getTextList();
-		this.stickers = dto.getStickerList();
+
+		this.images.clear();
+		this.images.addAll(dto.getImageList());
+
+		this.likes.clear();
+		this.likes.addAll(dto.getLikesList());
+
+		this.texts.clear();
+		this.texts.addAll(dto.getTextList());
+
+		this.stickers.clear();
+		this.stickers.addAll(dto.getStickerList());
+
 		this.cntComment = dto.getCntComment();
 		this.cntLike = dto.getCntLike();
 	}

--- a/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
@@ -38,7 +38,7 @@ public class DiaryService {
 			throw new BadDateRequestException();
 	}
 
-	public Diary updateDiaryCntCommentAndCntLikes(Diary diary){
+	public Diary updateDiaryCntCommentAndCntLikes(Diary diary) {
 		int cntComment = commentRepository.countByDiaryId(diary.getId());
 		int cntLike = likesRepository.countByDiaryId(diary.getId());
 		diary.setCntComment(cntComment);
@@ -92,7 +92,7 @@ public class DiaryService {
 	public void updateDiary(LocalDate date, DiarySaveReqDto dto) throws IOException {
 		Diary diary = diaryRepository.findByDate(date)
 				.orElseThrow(DiaryNotFoundException::new);
-		Diary updatedDiary = diaryMapper.saveDiary(diary, dto);
+		Diary updatedDiary = diaryMapper.updateDiary(diary, dto);
 		diaryRepository.save(updatedDiary);
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/image/dto/ImageReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/image/dto/ImageReqDto.java
@@ -1,0 +1,31 @@
+package com.efub.lakkulakku.domain.image.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageReqDto {
+	private Integer id;
+	private Integer width;
+	private Integer height;
+	private Integer x;
+	private Integer y;
+	private Integer rotation;
+	private String url;
+
+	@Builder
+	public ImageReqDto(Integer id, Integer width, Integer height,
+					   Integer x, Integer y, Integer rotation,
+					   String url) {
+		this.id = id;
+		this.width = width;
+		this.height = height;
+		this.rotation = rotation;
+		this.x = x;
+		this.y = y;
+		this.url = url;
+	}
+}

--- a/src/main/java/com/efub/lakkulakku/domain/image/dto/ImageResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/image/dto/ImageResDto.java
@@ -15,13 +15,17 @@ public class ImageResDto {
 	private Integer height;
 	private Integer x;
 	private Integer y;
+	private Integer rotation;
 	private String url;
 
 	@Builder
-	public ImageResDto(UUID id, Integer width, Integer height, Integer x, Integer y, String url) {
+	public ImageResDto(UUID id, Integer width, Integer height,
+					   Integer x, Integer y, Integer rotation,
+					   String url) {
 		this.id = id;
 		this.width = width;
 		this.height = height;
+		this.rotation = rotation;
 		this.x = x;
 		this.y = y;
 		this.url = url;

--- a/src/main/java/com/efub/lakkulakku/domain/image/entity/Image.java
+++ b/src/main/java/com/efub/lakkulakku/domain/image/entity/Image.java
@@ -43,18 +43,24 @@ public class Image extends BaseTimeEntity {
 	@NotNull
 	private Integer y;
 
+	@Column(length = 20)
+	@NotNull
+	private Integer rotation;
+
 	@OneToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "file_id")
 	private File file;
 
 	@Builder
 	public Image(Diary diary, Integer width, Integer height,
-				 Integer x, Integer y, File file) {
+				 Integer x, Integer y, Integer rotation,
+				 File file) {
 		this.diary = diary;
 		this.width = width;
 		this.height = height;
 		this.x = x;
 		this.y = y;
+		this.rotation = rotation;
 		this.file = file;
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/image/repository/ImageRepository.java
@@ -4,13 +4,10 @@ import com.efub.lakkulakku.domain.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, UUID> {
 	Optional<Image> findById(UUID id);
-	List<Image> findAllByDiaryId(UUID id);
-	void deleteAllByDiaryId(UUID id);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/dto/LikeMapper.java
@@ -45,17 +45,6 @@ public class LikeMapper {
 				.build();
 	}
 
-
-	public Likes checkIsEntity(Diary diary, LikeResDto dto) {
-		Likes likes;
-
-		if (dto.getId() == null)
-			likes = toEntity(diary, dto);
-		else
-			likes = likesRepository.findById(dto.getId()).orElseThrow(LikeNotFoundException::new);
-		return likes;
-	}
-
 	public Likes toEntity(Diary diary, LikeResDto dto) {
 		if (diary == null || dto == null)
 			return null;
@@ -76,10 +65,5 @@ public class LikeMapper {
 				.diary(diary)
 				.users(user)
 				.build();
-	}
-
-	public Likes deleteAndCreateEntity(Diary diary, LikeResDto dto) {
-		likesRepository.deleteAllByDiaryId(diary.getId());
-		return toEntity(diary, dto);
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/likes/repository/LikesRepository.java
@@ -12,9 +12,12 @@ import java.util.UUID;
 @Repository
 public interface LikesRepository extends JpaRepository<Likes, UUID> {
 	Optional<Likes> findById(UUID id);
-  Optional<Likes> findByDiaryAndUsers(Diary diary, Users users);
+
+	Optional<Likes> findByDiaryAndUsers(Diary diary, Users users);
+
 	void deleteById(UUID id);
-  void deleteAllByDiaryId(UUID id);
+
 	boolean existsByDiaryAndUsers(Diary diary, Users user);
+
 	int countByDiaryId(UUID id);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerMapper.java
@@ -29,16 +29,6 @@ public class StickerMapper {
 				.build();
 	}
 
-//	public Sticker checkIsEntity(Diary diary, StickerResDto dto) {
-//		Sticker sticker;
-//
-//		if (dto.getId() == null)
-//			sticker = toEntity(diary, dto);
-//		else
-//			sticker = stickerRepository.findById(dto.getId()).orElseThrow(StickerNotFoundException::new);
-//		return sticker;
-//	}
-
 	public Sticker toEntity(Diary diary, StickerReqDto dto) {
 		if (diary == null || dto == null)
 			return null;
@@ -53,9 +43,5 @@ public class StickerMapper {
 				.category(dto.getCategory())
 				.url(dto.getUrl())
 				.build();
-	}
-
-	public void deleteByDiary(Diary diary){
-		stickerRepository.deleteAllByDiary(diary);
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerMapper.java
@@ -2,7 +2,6 @@ package com.efub.lakkulakku.domain.sticker.dto;
 
 import com.efub.lakkulakku.domain.diary.entity.Diary;
 import com.efub.lakkulakku.domain.sticker.entity.Sticker;
-import com.efub.lakkulakku.domain.sticker.exception.StickerNotFoundException;
 import com.efub.lakkulakku.domain.sticker.repository.StickerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -24,22 +23,23 @@ public class StickerMapper {
 				.height(entity.getHeight())
 				.x(entity.getX())
 				.y(entity.getY())
+				.rotation(entity.getRotation())
 				.category(entity.getCategory())
 				.url(entity.getUrl())
 				.build();
 	}
 
-	public Sticker checkIsEntity(Diary diary, StickerResDto dto) {
-		Sticker sticker;
+//	public Sticker checkIsEntity(Diary diary, StickerResDto dto) {
+//		Sticker sticker;
+//
+//		if (dto.getId() == null)
+//			sticker = toEntity(diary, dto);
+//		else
+//			sticker = stickerRepository.findById(dto.getId()).orElseThrow(StickerNotFoundException::new);
+//		return sticker;
+//	}
 
-		if (dto.getId() == null)
-			sticker = toEntity(diary, dto);
-		else
-			sticker = stickerRepository.findById(dto.getId()).orElseThrow(StickerNotFoundException::new);
-		return sticker;
-	}
-
-	public Sticker toEntity(Diary diary, StickerResDto dto) {
+	public Sticker toEntity(Diary diary, StickerReqDto dto) {
 		if (diary == null || dto == null)
 			return null;
 
@@ -49,13 +49,13 @@ public class StickerMapper {
 				.height(dto.getHeight())
 				.x(dto.getX())
 				.y(dto.getY())
+				.rotation(dto.getRotation())
 				.category(dto.getCategory())
 				.url(dto.getUrl())
 				.build();
 	}
 
-	public Sticker deleteAndCreateEntity(Diary diary, StickerResDto dto) {
-		stickerRepository.deleteAllByDiaryId(diary.getId());
-		return toEntity(diary, dto);
+	public void deleteByDiary(Diary diary){
+		stickerRepository.deleteAllByDiary(diary);
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerReqDto.java
@@ -1,0 +1,33 @@
+package com.efub.lakkulakku.domain.sticker.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StickerReqDto {
+	private Integer id;
+	private Integer width;
+	private Integer height;
+	private Integer x;
+	private Integer y;
+	private Integer rotation;
+	private String category;
+	private String url;
+
+	@Builder
+	public StickerReqDto(Integer id, Integer width, Integer height,
+						 Integer x, Integer y, Integer rotation,
+						 String category, String url) {
+		this.id = id;
+		this.width = width;
+		this.height = height;
+		this.x = x;
+		this.y = y;
+		this.rotation = rotation;
+		this.category = category;
+		this.url = url;
+	}
+}

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/dto/StickerResDto.java
@@ -15,17 +15,20 @@ public class StickerResDto {
 	private Integer height;
 	private Integer x;
 	private Integer y;
+	private Integer rotation;
 	private String category;
 	private String url;
 
 	@Builder
 	public StickerResDto(UUID id, Integer width, Integer height,
-						 Integer x, Integer y, String category, String url) {
+						 Integer x, Integer y, Integer rotation,
+						 String category, String url) {
 		this.id = id;
 		this.width = width;
 		this.height = height;
 		this.x = x;
 		this.y = y;
+		this.rotation = rotation;
 		this.category = category;
 		this.url = url;
 	}

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/entity/Sticker.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/entity/Sticker.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
-import org.springframework.data.relational.core.sql.In;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -45,6 +44,10 @@ public class Sticker extends BaseTimeEntity {
 
 	@Column(length = 20)
 	@NotNull
+	private Integer rotation;
+
+	@Column(length = 20)
+	@NotNull
 	private String category;
 
 	@Column(length = 2084)
@@ -53,12 +56,14 @@ public class Sticker extends BaseTimeEntity {
 
 	@Builder
 	public Sticker(Diary diary, Integer width, Integer height,
-				   Integer x, Integer y, String category, String url) {
+				   Integer x, Integer y, Integer rotation,
+				   String category, String url) {
 		this.diary = diary;
 		this.width = width;
 		this.height = height;
 		this.x = x;
 		this.y = y;
+		this.rotation = rotation;
 		this.category = category;
 		this.url = url;
 	}

--- a/src/main/java/com/efub/lakkulakku/domain/sticker/repository/StickerRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/sticker/repository/StickerRepository.java
@@ -10,5 +10,4 @@ import java.util.UUID;
 @Repository
 public interface StickerRepository extends JpaRepository<Sticker, UUID> {
 	Optional<Sticker> findById(UUID id);
-	void deleteAllByDiaryId(UUID id);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/stickerResource/service/StickerResourceService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/stickerResource/service/StickerResourceService.java
@@ -21,9 +21,9 @@ public class StickerResourceService {
 
 	public final String BASE_URL =
 			"https://s3.ap-northeast-2.amazonaws.com/lakku-lakku.com/sticker/";
-	public final String[] CATEGORY_NAME = new String[]{"basic", "botanical", "cute", "kitsch"};
-	public final String[] COMMON_NAME = new String[]{"%E1%84%86%E1%85%A9%E1%84%83%E1%85%A5%E1%86%AB", "bote_st_", "cute_st_", "%E1%84%8F%E1%85%B5%E1%84%8E%E1%85%B5"};
-	public final Integer[] IMAGE_COUNT = new Integer[]{56, 119, 111, 69};
+	public final String[] CATEGORY_NAME = new String[]{"basic", "cute", "kitsch", "botanical"};
+	public final String[] COMMON_NAME = new String[]{"%E1%84%86%E1%85%A9%E1%84%83%E1%85%A5%E1%86%AB", "cute_st_", "%E1%84%8F%E1%85%B5%E1%84%8E%E1%85%B5", "bote_st_"};
+	public final Integer[] IMAGE_COUNT = new Integer[]{56, 111, 69, 119};
 
 	public void saveStickerResource() {
 		for (int i = 0; i < 4; i++) {

--- a/src/main/java/com/efub/lakkulakku/domain/template/dto/TemplateMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/template/dto/TemplateMapper.java
@@ -27,8 +27,6 @@ public class TemplateMapper {
 		if (diary == null || dto == null)
 			return null;
 
-//		templateRepository.deleteById(diary.getTemplate().getId());
-
 		return Template.builder()
 				.diary(diary)
 				.url(dto.getUrl())

--- a/src/main/java/com/efub/lakkulakku/domain/text/dto/TextMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/dto/TextMapper.java
@@ -33,17 +33,6 @@ public class TextMapper {
 				.build();
 	}
 
-//	public Text checkIsEntity(Diary diary, TextResDto dto) {
-//		Text text;
-//
-//		if (dto.getId() == null)
-//			text = toEntity(diary, dto);
-//		else
-//			text = textRepository.findById(dto.getId()).orElseThrow(TextNotFoundException::new);
-//
-//		return text;
-//	}
-
 	public Text toEntity(Diary diary, TextReqDto dto) {
 		if (diary == null || dto == null)
 			return null;
@@ -62,9 +51,5 @@ public class TextMapper {
 				.y(dto.getY())
 				.rotation(dto.getRotation())
 				.build();
-	}
-
-	public void deleteByDiary(Diary diary) {
-		textRepository.deleteAllByDiary(diary);
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/text/dto/TextMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/dto/TextMapper.java
@@ -2,16 +2,15 @@ package com.efub.lakkulakku.domain.text.dto;
 
 import com.efub.lakkulakku.domain.diary.entity.Diary;
 import com.efub.lakkulakku.domain.text.entity.Text;
-import com.efub.lakkulakku.domain.text.exception.TextNotFoundException;
 import com.efub.lakkulakku.domain.text.repository.TextRepository;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class TextMapper {
 
-	private static TextRepository textRepository;
+	private final TextRepository textRepository;
 
 	public TextResDto toTextResDto(Text entity) {
 
@@ -30,21 +29,22 @@ public class TextMapper {
 				.content(entity.getContent())
 				.x(entity.getX())
 				.y(entity.getY())
+				.rotation(entity.getRotation())
 				.build();
 	}
 
-	public Text checkIsEntity(Diary diary, TextResDto dto) {
-		Text text;
+//	public Text checkIsEntity(Diary diary, TextResDto dto) {
+//		Text text;
+//
+//		if (dto.getId() == null)
+//			text = toEntity(diary, dto);
+//		else
+//			text = textRepository.findById(dto.getId()).orElseThrow(TextNotFoundException::new);
+//
+//		return text;
+//	}
 
-		if (dto.getId() == null)
-			text = toEntity(diary, dto);
-		else
-			text = textRepository.findById(dto.getId()).orElseThrow(TextNotFoundException::new);
-
-		return text;
-	}
-
-	public Text toEntity(Diary diary, TextResDto dto) {
+	public Text toEntity(Diary diary, TextReqDto dto) {
 		if (diary == null || dto == null)
 			return null;
 
@@ -60,11 +60,11 @@ public class TextMapper {
 				.content(dto.getContent())
 				.x(dto.getX())
 				.y(dto.getY())
+				.rotation(dto.getRotation())
 				.build();
 	}
 
-	public Text deleteAndCreateEntity(Diary diary, TextResDto dto) {
-		textRepository.deleteAllByDiaryId(diary.getId());
-		return toEntity(diary, dto);
+	public void deleteByDiary(Diary diary) {
+		textRepository.deleteAllByDiary(diary);
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/text/dto/TextReqDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/dto/TextReqDto.java
@@ -1,0 +1,43 @@
+package com.efub.lakkulakku.domain.text.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TextReqDto {
+
+	private Integer id;
+	private String style;
+	private Integer weight;
+	private Integer size;
+	private Integer width;
+	private Integer height;
+	private String align;
+	private String color;
+	private String content;
+	private Integer x;
+	private Integer y;
+	private Integer rotation;
+
+	@Builder
+	public TextReqDto(Integer id, String style, Integer weight, Integer size,
+					  Integer width, Integer height,
+					  String align, String color, String content,
+					  Integer x, Integer y, Integer rotation) {
+		this.id = id;
+		this.style = style;
+		this.weight = weight;
+		this.size = size;
+		this.width = width;
+		this.height = height;
+		this.align = align;
+		this.color = color;
+		this.content = content;
+		this.x = x;
+		this.y = y;
+		this.rotation = rotation;
+	}
+}

--- a/src/main/java/com/efub/lakkulakku/domain/text/dto/TextResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/dto/TextResDto.java
@@ -21,11 +21,13 @@ public class TextResDto {
 	private String content;
 	private Integer x;
 	private Integer y;
+	private Integer rotation;
 
 	@Builder
 	public TextResDto(UUID id, String style, Integer weight, Integer size,
-					  Integer width, Integer height, String align, String color,
-					  String content, Integer x, Integer y) {
+					  Integer width, Integer height,
+					  String align, String color, String content,
+					  Integer x, Integer y, Integer rotation) {
 		this.id = id;
 		this.style = style;
 		this.weight = weight;
@@ -37,5 +39,6 @@ public class TextResDto {
 		this.content = content;
 		this.x = x;
 		this.y = y;
+		this.rotation = rotation;
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/text/entity/Text.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/entity/Text.java
@@ -65,10 +65,14 @@ public class Text extends BaseTimeEntity {
 	@NotNull
 	private Integer y;
 
+	@Column(length = 20)
+	@NotNull
+	private Integer rotation;
+
 	@Builder
 	public Text(Diary diary, String style, Integer weight, Integer size,
 				Integer width, Integer height, String align, String color, String content,
-				Integer x, Integer y) {
+				Integer x, Integer y, Integer rotation) {
 		this.diary = diary;
 		this.style = style;
 		this.weight = weight;
@@ -80,5 +84,6 @@ public class Text extends BaseTimeEntity {
 		this.content = content;
 		this.x = x;
 		this.y = y;
+		this.rotation = rotation;
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/text/repository/TextRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/text/repository/TextRepository.java
@@ -10,5 +10,4 @@ import java.util.UUID;
 @Repository
 public interface TextRepository extends JpaRepository<Text, UUID> {
 	Optional<Text> findById(UUID id);
-	void deleteAllByDiaryId(UUID id);
 }


### PR DESCRIPTION
1. LookupReqDto 생성
- 프론트에서 임시로 정수형 id를 주기로 함
- [req] 프론트->백은 정수형 id / [res] 백->프론트는 UUID형 id로 응답이 나뉘게 되어 req dto를 새롭게 생성

2. ResDto 필드 수정
- 이미지 : rotation 및 url 필드 추가
- 스티커 : rotation, category, url 필드 추가
- 텍스트 : rotation 필드 추가

3. /update 완성
4. /edit : basic -> cute -> kitsch -> botanical 순서로 응답 조정