### PR TITLE
feat: 홈 api 분리, 댓글 스티커 저장

### DIFF
--- a/src/main/java/com/efub/lakkulakku/domain/stickerResource/controller/StickerResourceController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/stickerResource/controller/StickerResourceController.java
@@ -18,4 +18,10 @@ public class StickerResourceController {
 //		stickerResourceService.saveStickerResource();
 //		return ResponseEntity.ok("기본 스티커 저장 성공");
 //	}
+
+//	@GetMapping("/sticker")
+//	public ResponseEntity<String> saveDB() {
+//		stickerResourceService.saveCommentStickerResource();
+//		return ResponseEntity.ok("댓글 스티커 저장 성공");
+//	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/stickerResource/service/StickerResourceService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/stickerResource/service/StickerResourceService.java
@@ -37,6 +37,16 @@ public class StickerResourceService {
 		}
 	}
 
+	public void saveCommentStickerResource() {
+		for (int i = 0; i < 8; i++) {
+			String URL = BASE_URL.concat("comment").concat(Integer.toString(i+1)).concat(".png");
+
+			StickerResource stickerResource = StickerResource.builder()
+					.category("comment").url(URL).build();
+			stickerResourceRepository.save(stickerResource);
+		}
+	}
+
 	public List<StickerResourceResDto> getStickersByLatest() {
 		return stickerResourceRepository.findAll().stream().map(stickerResourceMapper::toStickerResourceResDto).collect(Collectors.toList());
 	}

--- a/src/main/java/com/efub/lakkulakku/domain/users/controller/HomeController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/controller/HomeController.java
@@ -1,7 +1,10 @@
 package com.efub.lakkulakku.domain.users.controller;
 
 
+import com.efub.lakkulakku.domain.diary.dto.DiaryHomeResDto;
+import com.efub.lakkulakku.domain.notification.dto.NotificationHomeResDto;
 import com.efub.lakkulakku.domain.users.dto.HomeResDto;
+import com.efub.lakkulakku.domain.users.dto.ProfileUpdateResDto;
 import com.efub.lakkulakku.domain.users.entity.Users;
 import com.efub.lakkulakku.domain.users.exception.UserNotFoundException;
 import com.efub.lakkulakku.domain.users.repository.UsersRepository;
@@ -10,9 +13,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
-@RequestMapping({"/api/v1/home/{year}/{month}", "/api/v1/home"})
+@RequestMapping("/api/v1/home")
 @RequiredArgsConstructor
 public class HomeController {
 
@@ -29,5 +34,33 @@ public class HomeController {
 
 		return ResponseEntity.ok()
 				.body(usersService.getHome(user, year, month));
+	}
+
+	@GetMapping("/diary/{year}/{month}")
+	public List<DiaryHomeResDto> getHomeDiaryByDate(@PathVariable(value = "year", required = false) String year, @PathVariable(value = "month", required = false) String month, @RequestParam String nickname) {
+		//TODO : LocalDateTime의 범위를 넘어가는 경우 에러 발생
+//		if (Integer.parseInt(year) <= 1969 || Integer.parseInt(year) >= 2100)
+//			throw new BadDateRequestException();
+		Users user = usersRepository.findByNickname(nickname)
+				.orElseThrow(() -> new UserNotFoundException());
+
+		return usersService.getHomeDiary(user, year, month);
+	}
+
+	@GetMapping("/user")
+	public ResponseEntity<ProfileUpdateResDto> getHomeUser(@RequestParam String nickname) {
+		Users user = usersRepository.findByNickname(nickname)
+				.orElseThrow(() -> new UserNotFoundException());
+
+		return ResponseEntity.ok()
+				.body(new ProfileUpdateResDto(user));
+	}
+
+	@GetMapping("/alarm")
+	public List<NotificationHomeResDto> getHomeAlarm(@RequestParam String nickname) {
+		Users user = usersRepository.findByNickname(nickname)
+				.orElseThrow(() -> new UserNotFoundException());
+
+		return usersService.getHomeAlarm(user);
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/users/controller/HomeController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/controller/HomeController.java
@@ -36,7 +36,7 @@ public class HomeController {
 				.body(usersService.getHome(user, year, month));
 	}
 
-	@GetMapping("/diary/{year}/{month}")
+	@GetMapping({"/diary/{year}/{month}", "/diary"})
 	public List<DiaryHomeResDto> getHomeDiaryByDate(@PathVariable(value = "year", required = false) String year, @PathVariable(value = "month", required = false) String month, @RequestParam String nickname) {
 		//TODO : LocalDateTime의 범위를 넘어가는 경우 에러 발생
 //		if (Integer.parseInt(year) <= 1969 || Integer.parseInt(year) >= 2100)

--- a/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
@@ -1,6 +1,12 @@
 package com.efub.lakkulakku.domain.users.service;
 
+import com.efub.lakkulakku.domain.diary.dto.DiaryHomeMapper;
+import com.efub.lakkulakku.domain.diary.dto.DiaryHomeResDto;
+import com.efub.lakkulakku.domain.diary.repository.DiaryRepository;
 import com.efub.lakkulakku.domain.friend.exception.UserNotFoundException;
+import com.efub.lakkulakku.domain.notification.dto.NotificationHomeMapper;
+import com.efub.lakkulakku.domain.notification.dto.NotificationHomeResDto;
+import com.efub.lakkulakku.domain.notification.repository.NotificationRepository;
 import com.efub.lakkulakku.domain.profile.ProfileRepository;
 import com.efub.lakkulakku.domain.profile.entity.Profile;
 import com.efub.lakkulakku.domain.users.dto.WithdrawReqDto;
@@ -17,6 +23,8 @@ import javax.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +32,10 @@ public class UsersService {
 
 	private final UsersRepository usersRepository;
 	private final ProfileRepository profileRepository;
+	private final NotificationRepository notificationRepository;
+	private final NotificationHomeMapper notificationHomeMapper;
+	private final DiaryRepository diaryRepository;
+	private final DiaryHomeMapper diaryHomeMapper;
 	private final HomeMapper homeMapper;
 
 	private final PasswordEncoder passwordEncoder;
@@ -117,6 +129,23 @@ public class UsersService {
 			return homeMapper.toHomeResDto(user, Integer.toString(nowYear), Integer.toString(nowMonth));
 		} else {
 			return homeMapper.toHomeResDto(user, year, month);
+		}
+	}
+
+	public List<NotificationHomeResDto> getHomeAlarm(Users user) {
+		return notificationRepository.findByUsersId(user).stream().map(notificationHomeMapper::toNotificationHomeResDto).collect(Collectors.toList());
+	}
+
+	public List<DiaryHomeResDto> getHomeDiary(Users user, String year, String month) {
+		if (year == null) {
+			Date date = new Date();
+			LocalDate localDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+			int nowYear = localDate.getYear();
+			int nowMonth = localDate.getMonthValue();
+
+			return diaryRepository.findUsersDiaryByYearAndMonth(user.getId(), Integer.toString(nowYear), Integer.toString(nowMonth)).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList());
+		} else {
+			return diaryRepository.findUsersDiaryByYearAndMonth(user.getId(), year, month).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList());
 		}
 	}
 


### PR DESCRIPTION
### 작업 개요
프론트 요청 반영 : 홈에 필요한 유저 정보, 알람, 다이어리 정보를 3개의 api로 분리 

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
--> 
1. 홈에 표시되는 한달치 다이어리의 uri: /home/diary/{year}/{month}?nickname={nickname}, 년월이 표시되지 않으면 현재 날짜를 기준으로 표시
3. 홈에 필요한 유저 정보 uri: /home/user?nickname={nickname}
4. 홈에 필요한 유저의 알람 정보 uri: /home/alarm?nickname={nickname}

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->
