### PR TITLE
feat: 프로필 api 수정

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -13,6 +13,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
+        client_max_body_size 10M;
     }
 
     location /health {

--- a/src/main/java/com/efub/lakkulakku/domain/file/repository/FileRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/file/repository/FileRepository.java
@@ -2,10 +2,12 @@ package com.efub.lakkulakku.domain.file.repository;
 
 import com.efub.lakkulakku.domain.file.entity.File;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import javax.transaction.Transactional;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +15,9 @@ import java.util.UUID;
 public interface FileRepository extends JpaRepository<File, UUID> {
     @Query("SELECT f FROM File f WHERE f.url=:url")
     Optional<File> findAllByUrl(@Param("url") String url);
+
+    @Transactional
+    @Modifying
+    @Query(value = "DELETE f FROM file f LEFT OUTER JOIN profile p ON f.id=p.profile_image_id WHERE p.users_id IS NULL AND f.url LIKE \"https://s3.ap-northeast-2.amazonaws.com/lakku-lakku.com/profile%\";", nativeQuery = true)
+    void deleteUnusedFiles();
 }

--- a/src/main/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/profile/controller/ProfileUpdateController.java
@@ -17,9 +17,8 @@ public class ProfileUpdateController {
 	@PutMapping
 	public ProfileUpdateResDto updateProfile(@RequestParam(value = "nickname") String nickname,
 											 @RequestParam("image") MultipartFile image,
-											 @RequestParam(value = "bio") String bio, @RequestParam(value = "url") String profileImageUrl) throws Exception {
-		return profileService.updateUserProfile(nickname, image, bio , profileImageUrl);
-
+											 @RequestParam(value = "bio") String bio) throws Exception {
+		return profileService.updateUserProfile(nickname, image, bio);
 
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/profile/service/ProfileService.java
@@ -65,7 +65,7 @@ public class ProfileService {
 		String fullFileName = fileInfo.get(2);
 		String fileExtension = fileInfo.get(1);
 
-		if (!(fileExtension.equals(".png") || fileExtension.equals(".jpg") || fileExtension.equals("jpeg")))
+		if (!(fileExtension.equals(".png") || fileExtension.equals(".jpg") || fileExtension.equals(".jpeg")))
 			throw new FileExtenstionException();
 
 		try (InputStream inputStream = multipartFile.getInputStream()) {
@@ -105,50 +105,24 @@ public class ProfileService {
 	}
 
 	public void updateImage(String category, Users user, MultipartFile multipartFile) throws FileExtenstionException {
-		if (multipartFile == null) {
-			if (user.getProfile().getFile() != null) {
-				user.getProfile().getFile();
-				deleteProfileImage(user);
-			}
+		if (multipartFile.isEmpty()) {
 			user.getProfile().updateFile(null);
-		} else {
-			if (user.getProfile().getFile() != null) {
-				user.getProfile().getFile();
-				deleteProfileImage(user);
-			} else {
-				System.out.println("유저 프로필이 비어있는 상태입니다.");
-			}
+		}
+		else {
 			File newFile = uploadImage(category, user.getNickname(), multipartFile);
-
 			user.getProfile().updateFile(newFile);
 		}
-		profileRepository.save(user.getProfile());
 	}
 
-	@Transactional
-	void updateBio(Users user, String bio) {
-		if (!user.getProfile().getBio().equals(bio)) {
-			Profile profile = user.getProfile();
-			profile.updateBio(bio);
-			profileRepository.save(profile);
-		}
-		System.out.println("user = " + user);
-	}
-
-	@Transactional
-	public ProfileUpdateResDto updateUserProfile(String nickname, MultipartFile image, String bio, String profileImageUrl) throws FileExtenstionException {
+	public ProfileUpdateResDto updateUserProfile(String nickname, MultipartFile image, String bio) throws FileExtenstionException {
 		Users entity = userRepository.findByNickname(nickname)
 				.orElseThrow(UserNotFoundException::new);
-		if (profileImageUrl.isEmpty() && image.isEmpty()) {
-			updateImage("profile", entity, null);
-			updateBio(entity, bio);
 
-		} else if (!profileImageUrl.isEmpty() && image.isEmpty()) {
-			updateBio(entity, bio);
-		} else {
-			updateImage("profile", entity, image);
-			updateBio(entity, bio);
-		}
+		updateImage("profile", entity, image);
+		entity.getProfile().updateBio(bio);
+		profileRepository.save(entity.getProfile());
+
+		fileRepository.deleteUnusedFiles();
 
 		return new ProfileUpdateResDto(entity);
 	}


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->
프론트 요청 반영 : 프로필 api 간단하게 수정

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. 프로필 api 에서 "url" param 을 삭제해 로직을 단순화했습니다. 테스트가 많이 필요합니다.
2. db 데이터를 pruning 하는 로직 (deleteUnusedFiles) 을 추가했습니다.
3. 이미지 파일 사이즈가 클 경우 413 에러가 날 수 있기 때문에 최대 10MB까지 업로드할 수 있도록 nginx 파일을 수정했습니다.

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->
