### PR TITLE
fix: 프론트 단에서 헤더에 있는 토큰값 보이지 않는 문제 해결

### DIFF
--- a/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
+++ b/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
@@ -18,6 +18,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -37,6 +39,7 @@ public class AppConfig {
 		configuration.addAllowedOrigin("https://lakku-lakku.netlify.app");
 		configuration.addAllowedOrigin("http://localhost:3000");
 		configuration.addAllowedHeader("*");
+		configuration.setExposedHeaders(Arrays.asList("Set-Cookie"));
 		configuration.addAllowedMethod("*");
 		configuration.setAllowCredentials(true);
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
- 프론트에서 토큰을 담은 헤더가 보이지 않는 문제를 해결하기 위해 토큰을 담은 헤더가 노출될 수 있도록 설정

### 작업 개요
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
토큰을 바디가 아닌 헤더의 쿠키로 세팅하여 보내는 방식으로 변경했더니 CORS 에러가 발생했습니다. 
원인은 ACCESS-CONTROL-ALLOW-HEADERS를 따로 설정하지 않아서 였습니다. 
그래서 해당 'Set-Cookie'가 보일 수 있도록 수정했습니다. 
### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->
