### PR TITLE
fix : 로그인, 토큰 재발급 로직 변경 

### DIFF
--- a/src/main/java/com/efub/lakkulakku/domain/users/dto/LoginInfoDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/dto/LoginInfoDto.java
@@ -22,6 +22,7 @@ public class LoginInfoDto {
 	public LoginResDto toLoginResDto() {
 		return LoginResDto.builder()
 				.nickname(this.nickname)
+				.accessToken(this.accessToken)
 				.build();
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/users/dto/LoginResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/dto/LoginResDto.java
@@ -9,9 +9,12 @@ import lombok.NoArgsConstructor;
 public class LoginResDto {
 	private String nickname;
 
+	private String accessToken;
+
 	@Builder
-	public LoginResDto(String nickname)
+	public LoginResDto(String nickname, String accessToken)
 	{
 		this.nickname = nickname;
+		this.accessToken = accessToken;
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
+++ b/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
@@ -39,7 +39,7 @@ public class AppConfig {
 		configuration.addAllowedOrigin("https://lakku-lakku.netlify.app");
 		configuration.addAllowedOrigin("http://localhost:3000");
 		configuration.addAllowedHeader("*");
-		configuration.setExposedHeaders(Arrays.asList("Set-Cookie"));
+		configuration.addExposedHeader("Set-Cookie");
 		configuration.addAllowedMethod("*");
 		configuration.setAllowCredentials(true);
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/efub/lakkulakku/global/config/jwt/JwtProvider.java
+++ b/src/main/java/com/efub/lakkulakku/global/config/jwt/JwtProvider.java
@@ -107,4 +107,9 @@ public class JwtProvider {
 		redisService.setValues(blackListATPrefix + accessToken, userId, Duration.ofMillis(expiredAccessTokenTime));
 		redisService.deleteValues(userId);
 	}
+
+
+
+
+
 }


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->
로그인 , 재발급 요청 시 엑세스 토큰과 리프레시 토큰을 주는 방법을 변경 
### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
엑세스, 리프레시 토큰을 둘 다 쿠키로 주게 되면 httponly로 인해 자바스크립트로 읽어오지 못하는 문제로 인해 엑세스 토큰은 바디로, 리프레시 토큰은 쿠키로 주는 것으로 변경했습니다. 
### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->
