### PR TITLE
feat: 회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/entity/Diary.java
@@ -50,7 +50,7 @@ public class Diary extends BaseTimeEntity {
 	@Column(length = 5)
 	private String titleEmoji;
 
-	@OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "diary", cascade = CascadeType.PERSIST, orphanRemoval = true)
 	private List<Comment> comments = new ArrayList<>();
 
 	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/efub/lakkulakku/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/repository/DiaryRepository.java
@@ -25,4 +25,5 @@ public interface DiaryRepository extends JpaRepository<Diary, UUID> {
 
 	Optional<Diary> findByDate(LocalDate date);
 	Optional<Diary> findByDateAndUserId(LocalDate date, UUID userId);
+	List<Diary> findByUser(Users users);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/diary/service/DiaryService.java
@@ -98,4 +98,10 @@ public class DiaryService {
 		Diary updatedDiary = diaryMapper.updateDiary(diary, dto);
 		diaryRepository.save(updatedDiary);
 	}
+
+	@Transactional
+	public void deleteAllDiary(Users users){
+		List<Diary> diaryList = diaryRepository.findByUser(users);
+		diaryRepository.deleteAll(diaryList);
+	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/friend/entity/Friend.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/entity/Friend.java
@@ -28,7 +28,7 @@ public class Friend extends BaseTimeEntity {
 	@JoinColumn(name = "users_id")
 	private Users userId;
 
-	@ManyToOne
+	@ManyToOne(cascade = CascadeType.REMOVE)
 	@JoinColumn(name = "target_id")
 	private Users targetId;
 

--- a/src/main/java/com/efub/lakkulakku/domain/friend/service/FriendService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/friend/service/FriendService.java
@@ -96,9 +96,17 @@ public class FriendService {
 	@Transactional
 	public void deleteFriend(FriendReqDto reqDto, Users user) {
 		Users delFriend = usersRepository.findByUid(reqDto.getUid())
-				.orElseThrow(() -> new UserNotFoundException());
+				.orElseThrow(UserNotFoundException::new);
 		UUID id = isFriend(user, delFriend);
 		friendRepository.deleteById(id);
+	}
+
+	@Transactional
+	public void deleteAllFriend(Users users){
+		List<Friend> friendUserList = friendRepository.findAllByUserId(users);
+		List<Friend> friendTargetList = friendRepository.findAllByTargetId(users);
+		friendRepository.deleteAll(friendUserList);
+		friendRepository.deleteAll(friendTargetList);
 	}
 
 	@Transactional

--- a/src/main/java/com/efub/lakkulakku/domain/users/controller/WithdrawalController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/controller/WithdrawalController.java
@@ -1,14 +1,16 @@
 package com.efub.lakkulakku.domain.users.controller;
 
-import com.efub.lakkulakku.domain.users.dto.LoginResDto;
+import com.efub.lakkulakku.domain.diary.service.DiaryService;
+import com.efub.lakkulakku.domain.friend.exception.UserNotFoundException;
+import com.efub.lakkulakku.domain.friend.service.FriendService;
 import com.efub.lakkulakku.domain.users.dto.WithdrawReqDto;
+import com.efub.lakkulakku.domain.users.dto.WithdrawResDto;
+import com.efub.lakkulakku.domain.users.entity.Users;
+import com.efub.lakkulakku.domain.users.repository.UsersRepository;
 import com.efub.lakkulakku.domain.users.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -19,11 +21,24 @@ import static com.efub.lakkulakku.global.constant.ResponseConstant.WITHDRAW_SUCC
 @RequiredArgsConstructor
 public class WithdrawalController {
 
+	private final UsersRepository usersRepository;
 	private final UsersService usersService;
+	private final DiaryService diaryService;
+	private final FriendService friendService;
 
-	/*@PostMapping("/withdrawal")
-	public ResponseEntity<LoginResDto> withdrawal(@Valid @RequestBody WithdrawReqDto withdrawReqDto) {
-		usersService.deleteUser(withdrawReqDto);
-		return ResponseEntity.ok(LoginResDto.builder().message(WITHDRAW_SUCCESS).build());
-	}*/
+	@DeleteMapping("/withdrawal")
+	public ResponseEntity<WithdrawResDto> withdrawal(@Valid @RequestBody WithdrawReqDto withdrawReqDto) {
+		Users users = usersRepository.findByNickname(withdrawReqDto.getNickname())
+				.orElseThrow(UserNotFoundException::new);
+
+		diaryService.deleteAllDiary(users);
+		friendService.deleteAllFriend(users);
+		usersRepository.delete(users);
+
+		WithdrawResDto dto = WithdrawResDto.builder()
+				.nickname(withdrawReqDto.getNickname())
+				.message(WITHDRAW_SUCCESS)
+				.build();
+		return ResponseEntity.ok(dto);
+	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/users/dto/WithdrawResDto.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/dto/WithdrawResDto.java
@@ -1,0 +1,19 @@
+package com.efub.lakkulakku.domain.users.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WithdrawResDto {
+
+	private String nickname;
+	private String message;
+
+	@Builder
+	public WithdrawResDto(String nickname, String message){
+		this.nickname = nickname;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/entity/Users.java
@@ -41,7 +41,7 @@ public class Users extends BaseTimeEntity {
 	@NotNull
 	private String nickname;
 
-	@OneToOne(mappedBy = "users")
+	@OneToOne(mappedBy = "users", cascade = CascadeType.REMOVE)
 	@JoinColumn(name = "profile_id")
 	private Profile profile;
 


### PR DESCRIPTION
### 작업 개요
회원 탈퇴 구현

### 작업 분류
- [ ] 버그 수정
- [X] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
[DELETE] /api/v1/users/withdrawal
회원 탈퇴 시 프로필, 유저, 다이어리, 친구가 삭제되도록 했습니다.
알림 테이블의 경우 다른 유저의 기록에 포함될 수 있으므로 삭제하지 않았습니다.

### 생각해볼 문제
JPA에서 cascade와 orphanremoval 둘 중에 하나만 쓰는 쪽으로 개선할 수 있을 것 같습니다
