### PR TITLE
Fix/notification

### DIFF
--- a/src/main/java/com/efub/lakkulakku/domain/notification/entity/Notification.java
+++ b/src/main/java/com/efub/lakkulakku/domain/notification/entity/Notification.java
@@ -25,7 +25,7 @@ public class Notification extends BaseTimeEntity {
 	@Column(length = 16)
 	private UUID id;
 
-	@ManyToOne(cascade = CascadeType.ALL)
+	@ManyToOne
 	@JoinColumn(name = "users_id") //알람을 받는 유저
 	private Users receiver;
 

--- a/src/main/java/com/efub/lakkulakku/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/efub/lakkulakku/domain/notification/repository/NotificationRepository.java
@@ -1,8 +1,6 @@
 package com.efub.lakkulakku.domain.notification.repository;
 
-import com.efub.lakkulakku.domain.diary.entity.Diary;
 import com.efub.lakkulakku.domain.notification.entity.Notification;
-import com.efub.lakkulakku.domain.users.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,5 +15,10 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 	@Query(value = "SELECT * FROM notification n " +
 					"WHERE n.users_id=:usersId " +
 					"ORDER BY n.created_on desc LIMIT 5", nativeQuery = true)
+	List<Notification> findByUsersIdLimit(@Param("usersId") UUID usersId);
+
+	@Query(value = "SELECT * FROM notification n " +
+			"WHERE n.users_id=:usersId " +
+			"ORDER BY n.created_on desc", nativeQuery = true)
 	List<Notification> findByUsersId(@Param("usersId") UUID usersId);
 }

--- a/src/main/java/com/efub/lakkulakku/domain/stickerResource/controller/StickerResourceController.java
+++ b/src/main/java/com/efub/lakkulakku/domain/stickerResource/controller/StickerResourceController.java
@@ -14,13 +14,13 @@ public class StickerResourceController {
 	private final StickerResourceService stickerResourceService;
 
 //	@GetMapping("/sticker")
-//	public ResponseEntity<String> saveDB() {
+//	public ResponseEntity<String> saveStickerDB() {
 //		stickerResourceService.saveStickerResource();
 //		return ResponseEntity.ok("기본 스티커 저장 성공");
 //	}
-
-//	@GetMapping("/sticker")
-//	public ResponseEntity<String> saveDB() {
+//
+//	@GetMapping("/sticker/comment")
+//	public ResponseEntity<String> saveCommentStickerDB() {
 //		stickerResourceService.saveCommentStickerResource();
 //		return ResponseEntity.ok("댓글 스티커 저장 성공");
 //	}

--- a/src/main/java/com/efub/lakkulakku/domain/users/dto/HomeMapper.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/dto/HomeMapper.java
@@ -26,7 +26,7 @@ public class HomeMapper {
 		return HomeResDto.builder()
 				.user(new ProfileUpdateResDto(entity))
 				.diary(diaryRepository.findUsersDiaryByYearAndMonth(entity.getId(), year, month).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList()))
-				.alarm(notificationRepository.findByUsersId(entity.getId()).stream().map(NotificationMapper::toNotificationResDto).collect(Collectors.toList()))
+				.alarm(notificationRepository.findByUsersIdLimit(entity.getId()).stream().map(NotificationMapper::toNotificationResDto).collect(Collectors.toList()))
 				.build();
 	}
 }

--- a/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
+++ b/src/main/java/com/efub/lakkulakku/domain/users/service/UsersService.java
@@ -179,6 +179,7 @@ public class UsersService {
 			return diaryRepository.findUsersDiaryByYearAndMonth(user.getId(), year, month).stream().map(diaryHomeMapper::toDiaryHomeResDto).collect(Collectors.toList());
 		}
 	}
+
 	@Transactional
 	public List<NotificationResDto> findAllNotifications(Users user) {
 		List<Notification> notificationList = notificationRepository.findByUsersId(user.getId());

--- a/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
+++ b/src/main/java/com/efub/lakkulakku/global/config/AppConfig.java
@@ -61,7 +61,9 @@ public class AppConfig {
 				.and()
 				.authorizeRequests()
 				.requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-				.antMatchers("/api/v1/users/signup/**", "/api/v1/users/login", "/api/v1/users/re-issue", "/api/v1/settings", "/api/v1/users/certification/**").permitAll()
+				.antMatchers("/api/v1/users/signup/**", "/api/v1/users/login",
+						"/api/v1/users/re-issue", "/api/v1/settings", "/api/v1/users/certification/**",
+						"/api/v1/notification/subscribe", "/api/v1/util/**").permitAll()
 				.anyRequest().authenticated()
 				.and()
 				.addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
### 작업 개요
main 브랜치에서 notification 오류 해결

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
**1. notification `detached entity passed to persist` 에러 해결**
기존에는 notification과 user가 cascadeType.ALL로 묶여있었습니다. 
그 결과 notification이 생성될 떄마다 detached entity passed to persist 에러가 발생하게 되었습니다. 
해당 에러의 원인은 종속성 관계에 있는데, 예시를 들어보겠습니다. 
A 유저에게 보내는 notification a가 있습니다. -> A유저와 notification a 생성 및 연결
그 다음 A 유저에게 notification b를 발송하려 합니다 -> 이미 A유저 엔티티가 db에 존재하기 때문에 중복 저장됨
-> 에러 발생!

따라서 cascadeType.ALL을 제거하고 둘을 따로 저장했습니다. 
회원탈퇴로 테스트해보니 notification까지 잘 삭제되는 것을 확인했습니다. 

**2. repository에서 5개만 호출되었던 오류 해결**
알림의 경우 home에서 호출될 때는 최근 5개만 보여주고, 나머지 서비스단에서 호출될 때는 전체 리스트가 반환되어야 합니다.
그런데 두 개를 모두 하나의 함수(최근 5개만 보여주는 함수)로 사용하고 있었습니다.

따라서 최근 5개만 보여주는 함수와 전체 리스트를 반환하는 함수를 분리하였습니다.

**3. token 인증 없이 접근할 수 있는 url 생성**
- notification/subscribe와 /util 관련 url은 토큰 인증 없이 접근할 수 있도록 해놓았습니다.

### 생각해볼 문제
